### PR TITLE
Fix/signup#jason#02

### DIFF
--- a/action/auth-service/index.ts
+++ b/action/auth-service/index.ts
@@ -29,6 +29,16 @@ export interface VerifyCodeResponse {
   result?: any;
 }
 
+export interface CheckPhoneNumberResponse {
+  httpStatus: string;
+  isSuccess: boolean;
+  message: string;
+  code: number;
+  result: {
+    available: boolean;
+  };
+}
+
 export const sendVerificationCode = async (
   phoneNumber: string
 ): Promise<SendVerificationCodeResponse | null> => {
@@ -89,6 +99,33 @@ export const verifyCode = async (
     return data;
   } catch (error) {
     console.error('Error verifying code:', error);
+    return null;
+  }
+};
+
+export const checkPhoneNumber = async (
+  phoneNumber: string
+): Promise<CheckPhoneNumberResponse | null> => {
+  try {
+    const response = await fetch(
+      `${API_BASE_URL}/member-service/api/v1/check-phone-number?phoneNumber=${phoneNumber}`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      console.error('Failed to check phone number:', response.status);
+      return null;
+    }
+
+    const data: CheckPhoneNumberResponse = await response.json();
+    return data;
+  } catch (error) {
+    console.error('Error checking phone number:', error);
     return null;
   }
 };

--- a/components/(auth)/NicknameSection.tsx
+++ b/components/(auth)/NicknameSection.tsx
@@ -6,8 +6,10 @@ import { checkNicknameAvailability } from '@/action/validation-service';
 
 export default function NicknameSection({
   onNext,
+  isSubmitting = false,
 }: {
   onNext: (data: { nickname: string }) => void;
+  isSubmitting?: boolean;
 }) {
   const [nickname, setNickname] = useState('');
   const [nicknameError, setNicknameError] = useState('');
@@ -93,6 +95,7 @@ export default function NicknameSection({
             required
             error={!!nicknameError}
             helperText={nicknameError}
+            disabled={isSubmitting}
           />
           {isChecking && (
             <div className="absolute right-3 top-1/2 transform -translate-y-1/2">
@@ -117,9 +120,21 @@ export default function NicknameSection({
           type="button"
           className="w-full bg-custom-green text-black font-bold text-lg py-4 rounded-md h-14"
           onClick={handleNext}
-          disabled={!nickname.trim() || isAvailable === false || isChecking}
+          disabled={
+            !nickname.trim() ||
+            isAvailable === false ||
+            isChecking ||
+            isSubmitting
+          }
         >
-          회원가입
+          {isSubmitting ? (
+            <div className="flex items-center justify-center">
+              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-black mr-2"></div>
+              가입 중...
+            </div>
+          ) : (
+            '회원가입'
+          )}
         </Button>
       </div>
     </div>

--- a/components/(auth)/SignupInfoSection.tsx
+++ b/components/(auth)/SignupInfoSection.tsx
@@ -81,7 +81,11 @@ export default function SignupInfoSection({
     if (passwordError) {
       setPasswordError('');
     }
-    if (confirmPasswordError) {
+
+    // 확인 비밀번호와 일치 여부 실시간 확인
+    if (confirmPassword && value !== confirmPassword) {
+      setConfirmPasswordError('비밀번호가 일치하지 않습니다.');
+    } else if (confirmPassword && value === confirmPassword) {
       setConfirmPasswordError('');
     }
   };
@@ -89,8 +93,13 @@ export default function SignupInfoSection({
   const handleConfirmPasswordChange = (
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setConfirmPassword(e.target.value);
-    if (confirmPasswordError) {
+    const value = e.target.value;
+    setConfirmPassword(value);
+
+    // 실시간으로 비밀번호 일치 여부 확인
+    if (value && password !== value) {
+      setConfirmPasswordError('비밀번호가 일치하지 않습니다.');
+    } else {
       setConfirmPasswordError('');
     }
   };

--- a/components/(auth)/SignupSteps.tsx
+++ b/components/(auth)/SignupSteps.tsx
@@ -1,9 +1,10 @@
 'use client';
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { signup } from '@/action/auth-service/index';
 import { useFunnel } from '@/action/funnel';
 import { AlertContext } from '@/lib/Alert';
+import { useAlert } from '@/hooks/useAlert';
 
 import Stepper from './Stepper';
 import SignupInfoSection from './SignupInfoSection';
@@ -17,6 +18,8 @@ export default function SignupSteps() {
   const alertContext = useContext(AlertContext);
   const { Funnel, Step, setStep, formData, setFormData, currentStep } =
     useFunnel('step1');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { success, error: showError } = useAlert();
 
   const handleNext = (data: Record<string, string>, step: string) => {
     setStep(step);
@@ -24,22 +27,26 @@ export default function SignupSteps() {
   };
 
   const handleSubmit = async (data: Record<string, string>) => {
+    setIsSubmitting(true);
     try {
       const signupData = { ...formData, ...data };
       setFormData(signupData);
       const res = await signup(signupData);
 
       if (res.isSuccess) {
-        alertContext?.basic('회원가입이 완료되었습니다.');
+        success('🎉 회원가입이 완료되었습니다!');
         setTimeout(() => {
           router.push('/login');
-        }, 1000);
+        }, 1500);
       } else {
         const errorMessage = res.message || '회원가입에 실패했습니다.';
-        alertContext?.error(errorMessage);
+        showError(errorMessage);
       }
-    } catch {
-      console.error('Error during signup');
+    } catch (error) {
+      console.error('Error during signup:', error);
+      showError('회원가입 중 오류가 발생했습니다.');
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -80,6 +87,7 @@ export default function SignupSteps() {
             onNext={(data: { nickname: string }) => {
               handleSubmit(data);
             }}
+            isSubmitting={isSubmitting}
           />
         </Step>
       </Funnel>

--- a/components/(auth)/SignupSteps.tsx
+++ b/components/(auth)/SignupSteps.tsx
@@ -1,9 +1,8 @@
 'use client';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { signup } from '@/action/auth-service/index';
 import { useFunnel } from '@/action/funnel';
-import { AlertContext } from '@/lib/Alert';
 import { useAlert } from '@/hooks/useAlert';
 
 import Stepper from './Stepper';
@@ -15,7 +14,6 @@ import NicknameSection from './NicknameSection';
 
 export default function SignupSteps() {
   const router = useRouter();
-  const alertContext = useContext(AlertContext);
   const { Funnel, Step, setStep, formData, setFormData, currentStep } =
     useFunnel('step1');
   const [isSubmitting, setIsSubmitting] = useState(false);

--- a/components/common/CloseButton.tsx
+++ b/components/common/CloseButton.tsx
@@ -8,7 +8,7 @@ export default function CloseButton() {
   return (
     <button
       className="bg-custom-green rounded-full w-12 h-12"
-      onClick={() => router.back()}
+      onClick={() => router.push('/')}
     >
       <XIcon className="mx-auto" size={24} color="black" />
     </button>

--- a/components/organisms/LoginSection.tsx
+++ b/components/organisms/LoginSection.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { signIn } from 'next-auth/react';
 import LoginForm from '@/components/molecules/LoginForm';
 import { useAlert } from '@/hooks/useAlert';
+import Header from '@/components/layout/Header';
 
 interface LoginSectionProps {
   searchParams: Promise<{ callbackUrl: string }>;
@@ -75,6 +76,7 @@ export default function LoginSection({ searchParams }: LoginSectionProps) {
 
   return (
     <>
+      <Header title="로그인" isCloseButton={true} />
       <LoginForm
         onSubmit={handleLogin}
         error={error}


### PR DESCRIPTION
## 주요 변경사항

### 회원가입 UX 개선
- 회원가입 완료 후 로딩 상태 및 축하 메시지 추가
- 닉네임 입력창 비활성화 및 버튼 로딩 스피너 추가
- 회원가입 실패 시 useAlert를 사용한 에러 메시지 표시
- 비밀번호 일치 여부 실시간 확인 기능 추가

### 전화번호 인증 로직 개선
- 전화번호 변경 시 인증 상태 자동 리셋 기능 추가
- 중복체크 및 인증번호 발송 상태 초기화
- 새로운 전화번호로 중복체크부터 다시 실행

### 로그인 페이지 개선
- 로그인 페이지 닫기 버튼을 메인 페이지로 이동하도록 수정
- 헤더와 닫기 버튼 추가

## 기술적 개선사항
- useAlert 훅을 사용한 일관된 알림 시스템 적용
- 실시간 비밀번호 일치 여부 확인으로 UX 향상
- 전화번호 변경 시 자동 상태 리셋으로 사용자 혼란 방지

## 테스트 시나리오
1. 회원가입 시 비밀번호 불일치 시 실시간 에러 메시지 확인
2. 전화번호 변경 후 인증 상태 리셋 확인
3. 회원가입 완료 후 로딩 및 축하 메시지 확인
4. 로그인 페이지 닫기 버튼 동작 확인