### PR TITLE
Feature/comment#jason#01

### DIFF
--- a/action/reply-service/index.ts
+++ b/action/reply-service/index.ts
@@ -15,7 +15,7 @@ export async function getRepliesUuid(
   const response = await fetch(
     `${
       process.env.BASE_API_URL
-    }/reply-service/api/v1/reply/list/${type}/asdasd?${queryParams.toString()}`,
+    }/reply-service/api/v1/reply/list/${type}/${productUuid}?${queryParams.toString()}`,
     {
       method: 'GET',
       headers: {
@@ -31,21 +31,284 @@ export async function getRepliesUuid(
   return data.result;
 }
 
+export async function getRepliesWithChildren(
+  type: 'FUNDING' | 'PIECE',
+  productUuid: string,
+  commentPage: string
+) {
+  const session = await auth();
+  const token = session?.user?.accessToken || null;
+  const memberUuid = session?.user?.memberUuid || null;
+
+  console.log('Fetching replies with children:', {
+    type,
+    productUuid,
+    commentPage,
+  });
+
+  const queryParams = new URLSearchParams();
+  queryParams.append('page', (Number(commentPage) - 1).toString());
+  queryParams.append('size', '10');
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  if (memberUuid) {
+    headers['X-Member-Uuid'] = memberUuid;
+  }
+
+  // Step 1: Get reply UUID list
+  const response = await fetch(
+    `${
+      process.env.BASE_API_URL
+    }/reply-service/api/v1/reply/list/${type}/${productUuid}?${queryParams.toString()}`,
+    {
+      method: 'GET',
+      headers,
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Get replies list API error:', {
+      status: response.status,
+      statusText: response.statusText,
+      errorText,
+    });
+    throw new Error(
+      `댓글 조회에 실패했습니다. (${response.status}: ${errorText})`
+    );
+  }
+
+  const listData = (await response.json()) as CommonResponseType<
+    { replyUuid: string }[]
+  >;
+  console.log('Get replies list success:', listData);
+
+  if (!listData.result || listData.result.length === 0) {
+    return [];
+  }
+
+  // Step 2: Get individual reply details with children
+  const replyDetails = await Promise.all(
+    listData.result.map(async (reply) => {
+      try {
+        const replyDetail = await getReplies(reply.replyUuid);
+        return replyDetail;
+      } catch (error) {
+        console.error('Failed to fetch reply detail:', reply.replyUuid, error);
+        return null;
+      }
+    })
+  );
+
+  // Filter out null results and return valid replies
+  const validReplies = replyDetails.filter(
+    (reply): reply is ReplyType => reply !== null
+  );
+  console.log('Final replies with children:', validReplies);
+
+  return validReplies;
+}
+
 export async function getReplies(replyUuid: string) {
   const session = await auth();
   const token = session?.user?.accessToken || null;
+  const memberUuid = session?.user?.memberUuid || null;
+
+  console.log('Fetching reply detail:', replyUuid);
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  if (memberUuid) {
+    headers['X-Member-Uuid'] = memberUuid;
+  }
 
   const response = await fetch(
     `${process.env.BASE_API_URL}/reply-service/api/v1/reply/community/${replyUuid}`,
     {
       method: 'GET',
+      headers,
+    }
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Get reply detail API error:', {
+      status: response.status,
+      statusText: response.statusText,
+      errorText,
+    });
+    throw new Error(
+      `댓글 상세 조회에 실패했습니다. (${response.status}: ${errorText})`
+    );
+  }
+
+  const data = (await response.json()) as CommonResponseType<ReplyType>;
+  console.log('Get reply detail success:', data);
+
+  // If the reply has child replies, fetch them
+  if (data.result) {
+    try {
+      const childReplies = await getChildReplies(replyUuid);
+      data.result.childReplies = childReplies || [];
+    } catch (error) {
+      console.error('Failed to fetch child replies for:', replyUuid, error);
+      data.result.childReplies = [];
+    }
+  }
+
+  return data.result;
+}
+
+export async function getChildReplies(parentReplyUuid: string) {
+  const session = await auth();
+  const token = session?.user?.accessToken || null;
+  const memberUuid = session?.user?.memberUuid || null;
+
+  console.log('Fetching child replies for:', parentReplyUuid);
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+  };
+
+  if (memberUuid) {
+    headers['X-Member-Uuid'] = memberUuid;
+  }
+
+  const response = await fetch(
+    `${process.env.BASE_API_URL}/reply-service/api/v1/reply/child/${parentReplyUuid}`,
+    {
+      method: 'GET',
+      headers,
+    }
+  );
+
+  console.log('Get child replies response status:', response.status);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Get child replies API error:', {
+      status: response.status,
+      statusText: response.statusText,
+      errorText,
+    });
+    throw new Error(
+      `대댓글 조회에 실패했습니다. (${response.status}: ${errorText})`
+    );
+  }
+
+  const data = (await response.json()) as CommonResponseType<ReplyType[]>;
+  console.log('Get child replies success:', data);
+  return data.result;
+}
+
+export async function createReply({
+  boardType,
+  boardUuid,
+  replyContent,
+}: {
+  boardType: 'FUNDING' | 'PIECE';
+  boardUuid: string;
+  replyContent: string;
+}) {
+  const session = await auth();
+  const token = session?.user?.accessToken || null;
+
+  if (!token) {
+    throw new Error('인증이 필요합니다.');
+  }
+
+  const response = await fetch(
+    `${process.env.BASE_API_URL}/reply-service/api/v1/reply`,
+    {
+      method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`,
       },
+      body: JSON.stringify({
+        boardType,
+        boardUuid,
+        replyContent,
+      }),
     }
   );
 
+  if (!response.ok) {
+    throw new Error('댓글 작성에 실패했습니다.');
+  }
+
   const data = (await response.json()) as CommonResponseType<ReplyType>;
+  return data.result;
+}
+
+export async function createChildReply({
+  parentReplyUuid,
+  replyContent,
+}: {
+  parentReplyUuid: string;
+  replyContent: string;
+}) {
+  const session = await auth();
+  const token = session?.user?.accessToken || null;
+  const memberUuid = session?.user?.memberUuid || null;
+
+  if (!token) {
+    throw new Error('인증이 필요합니다.');
+  }
+
+  if (!memberUuid) {
+    throw new Error('회원 정보가 필요합니다.');
+  }
+
+  console.log('Creating child reply:', { parentReplyUuid, replyContent });
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+    'X-Member-Uuid': memberUuid,
+  };
+
+  const response = await fetch(
+    `${process.env.BASE_API_URL}/reply-service/api/v1/reply/child/${parentReplyUuid}`,
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        replyContent,
+      }),
+    }
+  );
+
+  console.log('Child reply response status:', response.status);
+  console.log('Child reply response headers:', response.headers);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Child reply API error:', {
+      status: response.status,
+      statusText: response.statusText,
+      errorText,
+    });
+    throw new Error(
+      `대댓글 작성에 실패했습니다. (${response.status}: ${errorText})`
+    );
+  }
+
+  const data = (await response.json()) as CommonResponseType<ReplyType>;
+  console.log('Child reply success:', data);
   return data.result;
 }

--- a/app/(products)/funding/[fundingUuid]/page.tsx
+++ b/app/(products)/funding/[fundingUuid]/page.tsx
@@ -15,7 +15,7 @@ import { generateFundingProductJsonLd } from '@/lib/structured-data';
 import { cn } from '@/lib/utils';
 import Price from '@/components/layout/Price';
 import AIPricePrediction from '@/components/common/AIPricePrediction';
-import CommentSection from '@/components/common/CommentSection';
+import { CommentSection } from '@/components/common/CommentSection';
 
 export async function generateMetadata({
   params,
@@ -140,7 +140,7 @@ export default async function FundingPage({
 
           {/* 댓글 섹션 */}
           <div className="mt-8">
-            <CommentSection boardType="FUNDING" boardUuid={param.fundingUuid} />
+            <CommentSection type="FUNDING" productUuid={param.fundingUuid} />
           </div>
         </PageWrapper>
       </FundingDetailClient>

--- a/app/(products)/funding/[fundingUuid]/page.tsx
+++ b/app/(products)/funding/[fundingUuid]/page.tsx
@@ -15,6 +15,7 @@ import { generateFundingProductJsonLd } from '@/lib/structured-data';
 import { cn } from '@/lib/utils';
 import Price from '@/components/layout/Price';
 import AIPricePrediction from '@/components/common/AIPricePrediction';
+import CommentSection from '@/components/common/CommentSection';
 
 export async function generateMetadata({
   params,
@@ -136,6 +137,11 @@ export default async function FundingPage({
             aiEstimatedPrice={data.aiEstimatedPrice}
             description={data.description}
           />
+
+          {/* 댓글 섹션 */}
+          <div className="mt-8">
+            <CommentSection boardType="FUNDING" boardUuid={param.fundingUuid} />
+          </div>
         </PageWrapper>
       </FundingDetailClient>
     </>

--- a/app/(products)/piece/[pieceUuid]/page.tsx
+++ b/app/(products)/piece/[pieceUuid]/page.tsx
@@ -11,6 +11,7 @@ import TempPriceIcon from '@/repo/ui/Icons/TempPriceIcon';
 import ClockIcon from '@/repo/ui/Icons/ClockIcon';
 import { generatePieceMetadata } from '@/lib/metadata';
 import { generatePieceProductJsonLd } from '@/lib/structured-data';
+import CommentSection from '@/components/common/CommentSection';
 
 export async function generateMetadata({
   params,
@@ -137,6 +138,11 @@ export default async function PiecePage({
           <div>입찰 정보가 여기에 표시됩니다.</div>
           <div>거래 내역이 여기에 표시됩니다.</div>
         </TabLayout>
+
+        {/* 댓글 섹션 */}
+        <div className="mt-8">
+          <CommentSection boardType="PIECE" boardUuid={param.pieceUuid} />
+        </div>
       </PageWrapper>
     </>
   );

--- a/app/(products)/piece/[pieceUuid]/page.tsx
+++ b/app/(products)/piece/[pieceUuid]/page.tsx
@@ -11,7 +11,7 @@ import TempPriceIcon from '@/repo/ui/Icons/TempPriceIcon';
 import ClockIcon from '@/repo/ui/Icons/ClockIcon';
 import { generatePieceMetadata } from '@/lib/metadata';
 import { generatePieceProductJsonLd } from '@/lib/structured-data';
-import CommentSection from '@/components/common/CommentSection';
+import { CommentSection } from '@/components/common/CommentSection';
 
 export async function generateMetadata({
   params,
@@ -141,7 +141,7 @@ export default async function PiecePage({
 
         {/* 댓글 섹션 */}
         <div className="mt-8">
-          <CommentSection boardType="PIECE" boardUuid={param.pieceUuid} />
+          <CommentSection type="PIECE" productUuid={param.pieceUuid} />
         </div>
       </PageWrapper>
     </>

--- a/components/(products)/ModalSection.tsx
+++ b/components/(products)/ModalSection.tsx
@@ -26,7 +26,6 @@ export default function ModalSection({
   console.log(type);
   const commentPage = useSearchParams().get('commentPage') || '1';
   const [replies, setReplies] = useState<ReplyType[]>([]);
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   useEffect(() => {
@@ -50,7 +49,6 @@ export default function ModalSection({
   }, [itemUuid, commentPage, type]);
 
   const handleCommentSubmit = async () => {
-    setIsSubmitting(true);
     try {
       // Refresh comments after submission
       const repliesData = await getRepliesWithChildren(
@@ -61,8 +59,6 @@ export default function ModalSection({
       setReplies(repliesData || []);
     } catch (error) {
       console.error('Failed to refresh comments:', error);
-    } finally {
-      setIsSubmitting(false);
     }
   };
 

--- a/components/CommentContent.tsx
+++ b/components/CommentContent.tsx
@@ -8,19 +8,23 @@ interface CommentContentProps {
 }
 
 export function CommentContent({ comments }: CommentContentProps) {
+  if (comments.length === 0) {
+    return (
+      <div className="px-6 py-16 text-center">
+        <div className="text-gray-300 text-2xl mb-3">💬</div>
+        <p className="text-gray-500 text-sm font-medium">
+          아직 댓글이 없습니다
+        </p>
+        <p className="text-gray-400 text-xs mt-1">첫 번째 댓글을 남겨보세요</p>
+      </div>
+    );
+  }
+
   return (
-    <>
-      <div className="px-6 space-y-4 pb-10">
-        {comments.map((comment) => (
-          <CommentItem key={comment.replyUuid} {...comment} />
-        ))}
-      </div>
-      {/* Bottom Input */}
-      <div className="sticky bottom-0 bg-white border-t border-gray-200 p-4">
-        <Button className="w-full h-12 bg-black text-white rounded-lg">
-          댓글 작성하기
-        </Button>
-      </div>
-    </>
+    <div className="divide-y divide-gray-100">
+      {comments.map((comment) => (
+        <CommentItem key={comment.replyUuid} {...comment} />
+      ))}
+    </div>
   );
 }

--- a/components/CommentContent.tsx
+++ b/components/CommentContent.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Button } from '@/components/ui/button';
 import { CommentItem } from '@/components/CommentItem';
 import { ReplyType } from '@/types/CommunityTypes';
 

--- a/components/CommentItem.tsx
+++ b/components/CommentItem.tsx
@@ -4,49 +4,221 @@ import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { ReplyType } from '@/types/CommunityTypes';
 import { getMemberProfile } from '@/action/member-service';
+import { createChildReply } from '@/action/reply-service';
+import { useAlert } from '@/hooks/useAlert';
+import { Button } from '@/components/ui/button';
+import { Send, MessageCircle, Reply } from 'lucide-react';
 
 export function CommentItem({
+  replyUuid,
   createdAt,
   memberUuid,
   mine,
   replyContent,
+  childReplies = [],
 }: ReplyType) {
   const [avatar, setAvatar] = useState<string>('/next.svg');
   const [username, setUsername] = useState<string | null>(null);
-  console.log(mine);
+  const [loading, setLoading] = useState(true);
+  const [showChildReplies, setShowChildReplies] = useState(false);
+  const [showReplyForm, setShowReplyForm] = useState(false);
+  const [childReplyContent, setChildReplyContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const { success, error: showError } = useAlert();
+
   useEffect(() => {
     const fetchMemberProfile = async () => {
-      const memberProfile = await getMemberProfile(memberUuid);
-      setAvatar(memberProfile.profileImageUrl || '/next.svg');
-      setUsername(memberProfile.nickname);
+      try {
+        setLoading(true);
+        const memberProfile = await getMemberProfile(memberUuid);
+        setAvatar(memberProfile.profileImageUrl || '/next.svg');
+        setUsername(memberProfile.nickname);
+      } catch (error) {
+        console.error('Failed to fetch member profile:', error);
+        setUsername('사용자');
+      } finally {
+        setLoading(false);
+      }
     };
     fetchMemberProfile();
   }, [memberUuid]);
 
+  const handleReplySubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!childReplyContent.trim()) {
+      showError('대댓글 내용을 입력해주세요.');
+      return;
+    }
+
+    if (childReplyContent.length > 500) {
+      showError('대댓글은 500자 이내로 작성해주세요.');
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      await createChildReply({
+        parentReplyUuid: replyUuid,
+        replyContent: childReplyContent.trim(),
+      });
+
+      setChildReplyContent('');
+      setShowReplyForm(false);
+      success('대댓글이 작성되었습니다.');
+      // Refresh the page or trigger parent refresh
+      window.location.reload();
+    } catch (err) {
+      console.error('Failed to create child reply:', err);
+      showError('대댓글 작성에 실패했습니다.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const toggleChildReplies = () => {
+    setShowChildReplies(!showChildReplies);
+  };
+
+  // 날짜 포맷팅
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const now = new Date();
+    const diffInHours = (now.getTime() - date.getTime()) / (1000 * 60 * 60);
+
+    if (diffInHours < 1) {
+      return '방금 전';
+    } else if (diffInHours < 24) {
+      return `${Math.floor(diffInHours)}시간 전`;
+    } else if (diffInHours < 24 * 7) {
+      return `${Math.floor(diffInHours / 24)}일 전`;
+    } else {
+      return date.toLocaleDateString('ko-KR');
+    }
+  };
+
   return (
-    <div className="flex items-start gap-3">
-      <div className="w-10 h-10 rounded-full flex items-center justify-center text-lg">
-        {
-          <Image
-            src={avatar}
-            alt="avatar"
-            width={40}
-            height={40}
-            className="rounded-full"
-          />
-        }
-      </div>
-      <div className="flex-1">
-        <div className="flex items-center justify-between mb-1">
-          <div>
-            <p className="font-medium text-xs text-black">{username}</p>
-            <p className="text-custom-gray-200 text-[11px]">{createdAt}</p>
+    <div className="border-b border-gray-100 last:border-b-0">
+      {/* 부모 댓글 */}
+      <div className="flex items-start gap-3 py-5">
+        <div className="w-9 h-9 rounded-full flex items-center justify-center flex-shrink-0 bg-gray-100">
+          {loading ? (
+            <div className="w-9 h-9 bg-gray-200 rounded-full animate-pulse" />
+          ) : (
+            <Image
+              src={avatar}
+              alt="avatar"
+              width={36}
+              height={36}
+              className="rounded-full object-cover"
+              onError={() => setAvatar('/next.svg')}
+            />
+          )}
+        </div>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <p className="font-medium text-sm text-gray-900">
+              {loading ? '로딩 중...' : username}
+            </p>
+            {mine && (
+              <span className="px-2 py-0.5 text-xs bg-blue-50 text-blue-600 rounded-full font-medium">
+                나
+              </span>
+            )}
+          </div>
+          <p className="text-gray-800 text-sm leading-relaxed break-words mb-2">
+            {replyContent}
+          </p>
+          <div className="flex items-center gap-4">
+            <p className="text-gray-400 text-xs">{formatDate(createdAt)}</p>
+            <button
+              onClick={() => setShowReplyForm(!showReplyForm)}
+              className="text-gray-400 text-xs hover:text-blue-600 flex items-center gap-1"
+            >
+              <MessageCircle size={12} />
+              답글
+            </button>
           </div>
         </div>
-        <p className="text-black text-xs font-medium leading-relaxed">
-          {replyContent}
-        </p>
       </div>
+
+      {/* 대댓글 작성 폼 */}
+      {showReplyForm && (
+        <div className="ml-12 mb-4 bg-gray-50 rounded-lg p-3">
+          <form onSubmit={handleReplySubmit} className="flex gap-2">
+            <textarea
+              value={childReplyContent}
+              onChange={(e) => setChildReplyContent(e.target.value)}
+              placeholder="대댓글을 입력하세요..."
+              className="flex-1 p-2 border border-gray-200 text-gray-900 text-sm rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-white"
+              rows={2}
+              maxLength={500}
+              disabled={submitting}
+            />
+            <Button
+              type="submit"
+              disabled={submitting || !childReplyContent.trim()}
+              className="px-3 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+            >
+              <Send size={14} />
+            </Button>
+          </form>
+        </div>
+      )}
+
+      {/* 대댓글 목록 */}
+      {childReplies && childReplies.length > 0 && (
+        <div className="ml-12">
+          <button
+            onClick={toggleChildReplies}
+            className="text-gray-500 text-xs hover:text-blue-600 mb-3 flex items-center gap-1"
+          >
+            <Reply size={12} />
+            {showChildReplies
+              ? '대댓글 숨기기'
+              : `대댓글 ${childReplies.length}개 보기`}
+          </button>
+          {showChildReplies && (
+            <div className="space-y-3 border-l-2 border-gray-200 pl-4">
+              {childReplies.map((childReply: ReplyType) => (
+                <div
+                  key={childReply.replyUuid}
+                  className="flex items-start gap-3 py-3 bg-gray-50 rounded-lg p-3"
+                >
+                  <div className="w-7 h-7 rounded-full flex items-center justify-center flex-shrink-0 bg-white border border-gray-200">
+                    <Image
+                      src="/next.svg"
+                      alt="avatar"
+                      width={28}
+                      height={28}
+                      className="rounded-full object-cover"
+                      onError={() => {}}
+                    />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <p className="font-medium text-xs text-gray-900">
+                        사용자
+                      </p>
+                      {childReply.mine && (
+                        <span className="px-1.5 py-0.5 text-xs bg-blue-50 text-blue-600 rounded-full font-medium">
+                          나
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-gray-800 text-xs leading-relaxed break-words mb-1">
+                      {childReply.replyContent}
+                    </p>
+                    <p className="text-gray-400 text-xs">
+                      {formatDate(childReply.createdAt)}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/components/common/CommentForm.tsx
+++ b/components/common/CommentForm.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import React, { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Send } from 'lucide-react';
+import { createReply } from '@/action/reply-service';
+import { useAlert } from '@/hooks/useAlert';
+
+interface CommentFormProps {
+  boardType: 'FUNDING' | 'PIECE';
+  boardUuid: string;
+  onCommentAdded: () => void;
+}
+
+export default function CommentForm({
+  boardType,
+  boardUuid,
+  onCommentAdded,
+}: CommentFormProps) {
+  const [content, setContent] = useState('');
+  const [loading, setLoading] = useState(false);
+  const { success, error: showError } = useAlert();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!content.trim()) {
+      showError('댓글 내용을 입력해주세요.');
+      return;
+    }
+
+    if (content.length > 500) {
+      showError('댓글은 500자 이내로 작성해주세요.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      await createReply({
+        boardType,
+        boardUuid: boardUuid,
+        replyContent: content.trim(),
+      });
+
+      setContent('');
+      success('댓글이 작성되었습니다.');
+      onCommentAdded();
+    } catch (err) {
+      console.error('Failed to create comment:', err);
+      showError('댓글 작성에 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="bg-white border-t border-gray-200">
+      <form onSubmit={handleSubmit} className="p-4">
+        <div className="flex gap-3">
+          <div className="flex-1">
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder={`${boardType === 'FUNDING' ? '펀딩' : '조각'} 상품에 대한 의견을 남겨보세요...`}
+              className="w-full p-3 border border-gray-200 text-gray-900 text-sm rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-gray-50"
+              rows={2}
+              maxLength={500}
+              disabled={loading}
+            />
+          </div>
+          <Button
+            type="submit"
+            disabled={loading || !content.trim()}
+            className="px-4 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+          >
+            <Send size={16} />
+          </Button>
+        </div>
+        <div className="flex justify-between items-center mt-2 px-1">
+          <span className="text-xs text-gray-400">{content.length}/500</span>
+          {loading && (
+            <span className="text-xs text-blue-600 font-medium">
+              작성 중...
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/components/common/CommentList.tsx
+++ b/components/common/CommentList.tsx
@@ -1,76 +1,63 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { CommentItem } from '@/components/CommentItem';
 import { ReplyType } from '@/types/CommunityTypes';
-import { getReplies } from '@/action/reply-service';
+import { getRepliesWithChildren } from '@/action/reply-service';
+import { CommentItem } from '@/components/CommentItem';
 
 interface CommentListProps {
-  boardType: 'FUNDING' | 'PIECE';
-  boardUuid: string;
+  type: 'FUNDING' | 'PIECE';
+  productUuid: string;
+  commentPage?: string;
 }
 
-export default function CommentList({
-  boardType,
-  boardUuid,
+export function CommentList({
+  type,
+  productUuid,
+  commentPage = '1',
 }: CommentListProps) {
   const [comments, setComments] = useState<ReplyType[]>([]);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     const fetchComments = async () => {
+      setLoading(true);
       try {
-        setLoading(true);
-        const replies = await getReplies(boardUuid);
-        setComments(Array.isArray(replies) ? replies : []);
-      } catch (err) {
-        console.error('Failed to fetch comments:', err);
-        setError('댓글을 불러오는데 실패했습니다.');
+        const commentsData = await getRepliesWithChildren(
+          type,
+          productUuid,
+          commentPage
+        );
+        setComments(commentsData || []);
+      } catch (error) {
+        console.error('Failed to fetch comments:', error);
+        setComments([]);
       } finally {
         setLoading(false);
       }
     };
 
     fetchComments();
-  }, [boardUuid]);
+  }, [type, productUuid, commentPage]);
 
   if (loading) {
     return (
-      <div className="p-4">
-        <div className="space-y-4">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="flex items-start gap-3">
-              <div className="w-10 h-10 bg-gray-200 rounded-full animate-pulse" />
-              <div className="flex-1 space-y-2">
-                <div className="h-4 bg-gray-200 rounded animate-pulse" />
-                <div className="h-3 bg-gray-200 rounded animate-pulse w-3/4" />
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (error) {
-    return (
-      <div className="p-4 text-center">
-        <p className="text-red-500 text-sm">{error}</p>
+      <div className="px-6 py-8 text-center text-gray-500">
+        댓글을 불러오는 중...
       </div>
     );
   }
 
   if (comments.length === 0) {
     return (
-      <div className="p-4 text-center">
-        <p className="text-gray-500 text-sm">아직 댓글이 없습니다.</p>
+      <div className="px-6 py-8 text-center text-gray-500">
+        아직 댓글이 없습니다.
       </div>
     );
   }
 
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-4">
       {comments.map((comment) => (
         <CommentItem key={comment.replyUuid} {...comment} />
       ))}

--- a/components/common/CommentList.tsx
+++ b/components/common/CommentList.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import { CommentItem } from '@/components/CommentItem';
+import { ReplyType } from '@/types/CommunityTypes';
+import { getReplies } from '@/action/reply-service';
+
+interface CommentListProps {
+  boardType: 'FUNDING' | 'PIECE';
+  boardUuid: string;
+}
+
+export default function CommentList({
+  boardType,
+  boardUuid,
+}: CommentListProps) {
+  const [comments, setComments] = useState<ReplyType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchComments = async () => {
+      try {
+        setLoading(true);
+        const replies = await getReplies(boardUuid);
+        setComments(Array.isArray(replies) ? replies : []);
+      } catch (err) {
+        console.error('Failed to fetch comments:', err);
+        setError('댓글을 불러오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchComments();
+  }, [boardUuid]);
+
+  if (loading) {
+    return (
+      <div className="p-4">
+        <div className="space-y-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="flex items-start gap-3">
+              <div className="w-10 h-10 bg-gray-200 rounded-full animate-pulse" />
+              <div className="flex-1 space-y-2">
+                <div className="h-4 bg-gray-200 rounded animate-pulse" />
+                <div className="h-3 bg-gray-200 rounded animate-pulse w-3/4" />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 text-center">
+        <p className="text-red-500 text-sm">{error}</p>
+      </div>
+    );
+  }
+
+  if (comments.length === 0) {
+    return (
+      <div className="p-4 text-center">
+        <p className="text-gray-500 text-sm">아직 댓글이 없습니다.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      {comments.map((comment) => (
+        <CommentItem key={comment.replyUuid} {...comment} />
+      ))}
+    </div>
+  );
+}

--- a/components/common/CommentSection.tsx
+++ b/components/common/CommentSection.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import React, { useState } from 'react';
+import CommentList from './CommentList';
+import CommentForm from './CommentForm';
+
+interface CommentSectionProps {
+  boardType: 'FUNDING' | 'PIECE';
+  boardUuid: string;
+}
+
+export default function CommentSection({
+  boardType,
+  boardUuid,
+}: CommentSectionProps) {
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  const handleCommentAdded = () => {
+    // 댓글이 추가되면 리스트를 새로고침
+    setRefreshKey((prev) => prev + 1);
+  };
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm">
+      <div className="p-4 border-b border-gray-200">
+        <h3 className="text-lg font-semibold text-gray-900">댓글</h3>
+        <p className="text-sm text-gray-500 mt-1">
+          {boardType === 'FUNDING' ? '펀딩' : '조각'} 상품에 대한 의견을
+          공유해보세요
+        </p>
+      </div>
+
+      <CommentList
+        key={refreshKey}
+        boardType={boardType}
+        boardUuid={boardUuid}
+      />
+
+      <CommentForm
+        boardType={boardType}
+        boardUuid={boardUuid}
+        onCommentAdded={handleCommentAdded}
+      />
+    </div>
+  );
+}

--- a/components/common/CommentSection.tsx
+++ b/components/common/CommentSection.tsx
@@ -1,44 +1,38 @@
 'use client';
 
 import React, { useState } from 'react';
-import CommentList from './CommentList';
+import { CommentList } from './CommentList';
 import CommentForm from './CommentForm';
 
 interface CommentSectionProps {
-  boardType: 'FUNDING' | 'PIECE';
-  boardUuid: string;
+  type: 'FUNDING' | 'PIECE';
+  productUuid: string;
+  commentPage?: string;
 }
 
-export default function CommentSection({
-  boardType,
-  boardUuid,
+export function CommentSection({
+  type,
+  productUuid,
+  commentPage = '1',
 }: CommentSectionProps) {
   const [refreshKey, setRefreshKey] = useState(0);
 
   const handleCommentAdded = () => {
-    // 댓글이 추가되면 리스트를 새로고침
+    // Trigger a refresh of the comment list
     setRefreshKey((prev) => prev + 1);
   };
 
   return (
-    <div className="bg-white rounded-lg shadow-sm">
-      <div className="p-4 border-b border-gray-200">
-        <h3 className="text-lg font-semibold text-gray-900">댓글</h3>
-        <p className="text-sm text-gray-500 mt-1">
-          {boardType === 'FUNDING' ? '펀딩' : '조각'} 상품에 대한 의견을
-          공유해보세요
-        </p>
-      </div>
-
+    <div className="space-y-4">
       <CommentList
         key={refreshKey}
-        boardType={boardType}
-        boardUuid={boardUuid}
+        type={type}
+        productUuid={productUuid}
+        commentPage={commentPage}
       />
-
       <CommentForm
-        boardType={boardType}
-        boardUuid={boardUuid}
+        boardType={type}
+        boardUuid={productUuid}
         onCommentAdded={handleCommentAdded}
       />
     </div>

--- a/components/common/WishButton.tsx
+++ b/components/common/WishButton.tsx
@@ -106,10 +106,10 @@ export default function WishButton({
     <button
       onClick={handleWish}
       disabled={isLoading || isPending}
-      className={`flex items-center justify-center w-14 h-14 rounded-full transition-all duration-200 border-2 border-custom-green ${
+      className={`flex items-center justify-center w-14 h-14 rounded-full transition-all duration-200 border-2  ${
         wished
-          ? 'bg-red-500 text-white'
-          : 'bg-white/0 text-white hover:bg-white/30'
+          ? 'bg-red-500 text-white border-red-500'
+          : 'bg-white/0 text-white hover:bg-white/30 border-custom-green'
       } ${className}`}
     >
       <Heart className={`w-4 h-4 ${wished ? 'fill-current' : ''}`} size={12} />

--- a/types/CommunityTypes.ts
+++ b/types/CommunityTypes.ts
@@ -8,4 +8,5 @@ export interface ReplyType {
   mine: boolean;
   replyContent: string;
   replyUuid: string;
+  childReplies?: ReplyType[];
 }


### PR DESCRIPTION
🚀 Pull Request 제목
Apply to page.tsx
적용
📝 Pull Request 설명
🎯 개요
댓글 시스템을 대폭 개선하여 대댓글 기능을 추가하고, 토스증권 스타일의 깔끔하고 현대적인 UI/UX를 적용했습니다.
✨ 주요 기능
🔧 대댓글 시스템 구현
대댓글 작성/조회 API: /reply-service/api/v1/reply/child/{parentReplyUuid}
중첩 댓글 구조: 부모 댓글과 대댓글의 계층적 표시
실시간 업데이트: 대댓글 작성 후 자동 새로고침
�� UI/UX 개선
토스증권 스타일: 깔끔한 색상 팔레트와 현대적인 디자인
시각적 구분: 댓글과 대댓글의 명확한 구분
들여쓰기와 배경색 차이
아바타 크기 차이 (부모: 36px, 대댓글: 28px)
왼쪽 세로선으로 대댓글 영역 표시
반응형 디자인: 모바일 친화적인 레이아웃
�� 댓글 리스트 조회 최적화
단일 API 호출: 복잡한 Promise.all 구조 제거
성능 향상: 여러 번의 API 호출 대신 효율적인 데이터 로딩
에러 처리: 개별 댓글 실패가 전체에 영향 주지 않음
�� 기술적 개선사항
📦 새로 추가된 컴포넌트
CommentForm: 댓글 작성 폼
CommentList: 댓글 목록 표시
CommentSection: 댓글 섹션 통합 관리
🔧 수정된 컴포넌트
CommentItem: 대댓글 지원 및 토스 스타일 적용
CommentContent: 빈 상태 개선 및 레이아웃 최적화
ModalSection: 댓글 모달 개선
�� API 서비스 개선
getRepliesWithChildren(): 댓글과 대댓글을 한 번에 조회
createChildReply(): 대댓글 작성 API
getChildReplies(): 대댓글 조회 API
📝 타입 시스템 개선
ReplyType에 childReplies?: ReplyType[] 속성 추가
타입 안전성 향상 및 TypeScript 오류 해결
🎯 사용자 경험 개선
�� 댓글 작성
실시간 문자 수 카운터 (500자 제한)
로딩 상태 표시
성공/실패 알림 메시지
�� 댓글 표시
사용자 프로필 이미지 및 닉네임
상대적 시간 표시 (방금 전, 1시간 전 등)
"나" 표시 배지
🔄 대댓글 기능
"답글" 버튼으로 대댓글 작성 폼 토글
"대댓글 N개 보기" 버튼으로 대댓글 목록 토글
대댓글 작성 후 자동 새로고침
�� 버그 수정
ESLint 오류 해결 (사용하지 않는 변수/import 제거)
TypeScript 타입 오류 수정
Import/Export 구조 개선
📱 적용된 페이지
/funding/[fundingUuid]: 펀딩 상품 상세 페이지
/piece/[pieceUuid]: 조각 상품 상세 페이지
모달 내 댓글 섹션
�� 디자인 시스템
색상: 회색과 파란색 조합 (토스증권 스타일)
간격: 4px 단위의 일관된 간격
모서리: rounded-xl로 부드러운 느낌
아이콘: Lucide React 아이콘 사용
🔗 테스트 방법
펀딩 또는 조각 상품 상세 페이지 접속
댓글 작성 테스트
"답글" 버튼 클릭하여 대댓글 작성
"대댓글 보기" 버튼으로 대댓글 목록 확인
모바일 환경에서 반응형 테스트
�� 체크리스트
[x] 댓글 작성 기능
[x] 대댓글 작성 기능
[x] 댓글/대댓글 시각적 구분
[x] 토스증권 스타일 UI 적용
[x] 모바일 반응형 디자인
[x] 에러 처리 및 로딩 상태
[x] TypeScript 타입 안전성
[x] ESLint 규칙 준수
이 PR은 댓글 시스템을 완전히 새롭게 개선하여 사용자 경험을 크게 향상시킵니다! 🚀