### PR TITLE
모달 드래그/백드롭 닫기 및 댓글 작성 폼 노출 개선

### DIFF
--- a/action/reply-service/index.ts
+++ b/action/reply-service/index.ts
@@ -312,3 +312,106 @@ export async function createChildReply({
   console.log('Child reply success:', data);
   return data.result;
 }
+
+export async function updateReply({
+  replyUuid,
+  replyContent,
+}: {
+  replyUuid: string;
+  replyContent: string;
+}) {
+  const session = await auth();
+  const token = session?.user?.accessToken || null;
+  const memberUuid = session?.user?.memberUuid || null;
+
+  if (!token) {
+    throw new Error('인증이 필요합니다.');
+  }
+
+  if (!memberUuid) {
+    throw new Error('회원 정보가 필요합니다.');
+  }
+
+  console.log('Updating reply:', { replyUuid, replyContent });
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+    'X-Member-Uuid': memberUuid,
+  };
+
+  const response = await fetch(
+    `${process.env.BASE_API_URL}/reply-service/api/v1/reply/${replyUuid}`,
+    {
+      method: 'PUT',
+      headers,
+      body: JSON.stringify({
+        replyContent,
+      }),
+    }
+  );
+
+  console.log('Update reply response status:', response.status);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Update reply API error:', {
+      status: response.status,
+      statusText: response.statusText,
+      errorText,
+    });
+    throw new Error(
+      `댓글 수정에 실패했습니다. (${response.status}: ${errorText})`
+    );
+  }
+
+  const data = (await response.json()) as CommonResponseType<ReplyType>;
+  console.log('Update reply success:', data);
+  return data.result;
+}
+
+export async function deleteReply(replyUuid: string) {
+  const session = await auth();
+  const token = session?.user?.accessToken || null;
+  const memberUuid = session?.user?.memberUuid || null;
+
+  if (!token) {
+    throw new Error('인증이 필요합니다.');
+  }
+
+  if (!memberUuid) {
+    throw new Error('회원 정보가 필요합니다.');
+  }
+
+  console.log('Deleting reply:', replyUuid);
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'Authorization': `Bearer ${token}`,
+    'X-Member-Uuid': memberUuid,
+  };
+
+  const response = await fetch(
+    `${process.env.BASE_API_URL}/reply-service/api/v1/reply/${replyUuid}`,
+    {
+      method: 'DELETE',
+      headers,
+    }
+  );
+
+  console.log('Delete reply response status:', response.status);
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error('Delete reply API error:', {
+      status: response.status,
+      statusText: response.statusText,
+      errorText,
+    });
+    throw new Error(
+      `댓글 삭제에 실패했습니다. (${response.status}: ${errorText})`
+    );
+  }
+
+  return true;
+}

--- a/app/(products)/funding/[fundingUuid]/page.tsx
+++ b/app/(products)/funding/[fundingUuid]/page.tsx
@@ -15,7 +15,6 @@ import { generateFundingProductJsonLd } from '@/lib/structured-data';
 import { cn } from '@/lib/utils';
 import Price from '@/components/layout/Price';
 import AIPricePrediction from '@/components/common/AIPricePrediction';
-import { CommentSection } from '@/components/common/CommentSection';
 
 export async function generateMetadata({
   params,

--- a/app/(products)/funding/[fundingUuid]/page.tsx
+++ b/app/(products)/funding/[fundingUuid]/page.tsx
@@ -137,11 +137,6 @@ export default async function FundingPage({
             aiEstimatedPrice={data.aiEstimatedPrice}
             description={data.description}
           />
-
-          {/* 댓글 섹션 */}
-          <div className="mt-8">
-            <CommentSection type="FUNDING" productUuid={param.fundingUuid} />
-          </div>
         </PageWrapper>
       </FundingDetailClient>
     </>

--- a/components/(main)/PurchaseModalSection.tsx
+++ b/components/(main)/PurchaseModalSection.tsx
@@ -56,9 +56,9 @@ export default function PurchaseModalSection() {
           closeModal();
         }}
       >
-        {(handleClose: () => void) => (
+        {() => (
           <>
-            <ModalHeader onClose={handleClose}>
+            <ModalHeader>
               <div className="px-6 pb-6">
                 <h1 className="text-black text-lg font-bold">충전하기</h1>
                 <p className="text-gray-600 text-sm">

--- a/components/(products)/ModalSection.tsx
+++ b/components/(products)/ModalSection.tsx
@@ -69,9 +69,9 @@ export default function ModalSection({
         isOpen={currentModal === 'comments'}
         onClose={() => closeModal()}
       >
-        {(handleClose: () => void) => (
+        {() => (
           <>
-            <ModalHeader onClose={handleClose}>
+            <ModalHeader>
               <div className="px-6 pb-4">
                 <h1 className="text-gray-900 text-lg font-semibold">
                   {productData.productName}
@@ -115,9 +115,9 @@ export default function ModalSection({
         isOpen={currentModal === 'details'}
         onClose={() => closeModal()}
       >
-        {(handleClose: () => void) => (
+        {() => (
           <>
-            <ModalHeader onClose={handleClose} />
+            <ModalHeader />
             <div className="space-y-4 px-6">
               <PriceInfo
                 currentPrice={productData.funding.piecePrice}

--- a/components/(products)/ModalSection.tsx
+++ b/components/(products)/ModalSection.tsx
@@ -83,9 +83,9 @@ export default function ModalSection({
               </div>
             </ModalHeader>
             <div className="flex flex-col h-full">
-              <div className="flex-1 overflow-y-auto">
+              <div className="overflow-y-auto px-6" style={{ height: '70%' }}>
                 {isLoading ? (
-                  <div className="px-6 py-16 text-center">
+                  <div className="py-16 text-center">
                     <div className="text-gray-300 text-2xl mb-3">⏳</div>
                     <p className="text-gray-500 text-sm font-medium">
                       댓글을 불러오는 중...
@@ -95,7 +95,11 @@ export default function ModalSection({
                   <CommentsContent comments={replies} />
                 )}
               </div>
-              <div className="border-t border-gray-200">
+
+              <div
+                className="border-t border-gray-200 bg-white flex-shrink-0"
+                style={{ height: '40%' }}
+              >
                 <CommentForm
                   boardType={type}
                   boardUuid={itemUuid}

--- a/components/ModalContainer.tsx
+++ b/components/ModalContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, type ReactNode } from 'react';
+import { useState, useEffect, useRef, type ReactNode } from 'react';
 
 interface ModalContainerProps {
   children: ReactNode | ((handleClose: () => void) => ReactNode);
@@ -17,6 +17,12 @@ export function ModalContainer({
 }: ModalContainerProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [isClosing, setIsClosing] = useState(false);
+  const [dragDistance, setDragDistance] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+  const touchStartY = useRef<number>(0);
+  const currentTouchY = useRef<number>(0);
+  const modalRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     if (isOpen) {
       // 뒤쪽 페이지 스크롤 비활성화
@@ -41,15 +47,66 @@ export function ModalContainer({
       document.body.style.overflow = 'unset';
       setIsVisible(false);
       setIsClosing(false);
+      setDragDistance(0);
       onClose?.();
     }, 300);
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      handleClose();
+    }
+  };
+
+  const handleTouchStart = (e: React.TouchEvent) => {
+    const touchY = e.touches[0].clientY;
+    const modalTop = modalRef.current?.getBoundingClientRect().top || 0;
+    const dragHandleHeight = 50; // 상단 50px 영역에서만 드래그 허용
+
+    // 모달 상단 영역에서만 드래그 시작 허용
+    if (touchY - modalTop > dragHandleHeight) {
+      return;
+    }
+
+    touchStartY.current = touchY;
+    currentTouchY.current = touchY;
+    setIsDragging(true);
+  };
+
+  const handleTouchMove = (e: React.TouchEvent) => {
+    if (!isDragging) return;
+
+    currentTouchY.current = e.touches[0].clientY;
+    const distance = currentTouchY.current - touchStartY.current;
+
+    // 아래로 드래그할 때만 반응 (양수 값)
+    if (distance > 0) {
+      setDragDistance(distance);
+      e.preventDefault(); // 스크롤 방지
+    }
+  };
+
+  const handleTouchEnd = () => {
+    if (!isDragging) return;
+
+    const distance = currentTouchY.current - touchStartY.current;
+    const threshold = 150; // 150px 이상 드래그하면 닫기
+
+    if (distance > threshold) {
+      handleClose();
+    } else {
+      // 임계값에 도달하지 않으면 원래 위치로 복원
+      setDragDistance(0);
+    }
+
+    setIsDragging(false);
   };
 
   if (!isOpen) return null;
 
   return (
     <div
-      className={`fixed inset-0 z-50 transform transition-transform duration-300 ease-in-out ${
+      className={`fixed inset-0 z-50 transform transition-transform duration-300 ease-in-out backdrop-blur-sm ${
         withAnimation
           ? isClosing
             ? 'translate-y-full'
@@ -58,9 +115,31 @@ export function ModalContainer({
               : 'translate-y-full'
           : ''
       }`}
+      style={{
+        backgroundColor: isDragging
+          ? `rgba(0, 0, 0, ${Math.max(0.1, 0.5 - dragDistance / 300)})`
+          : 'rgba(0, 0, 0, 0.5)',
+      }}
+      onClick={handleBackdropClick}
     >
-      <div className="h-full overflow-y-auto">
-        <div className="min-h-full bg-white">
+      <div
+        ref={modalRef}
+        className="h-full mt-20 rounded-t-3xl overflow-hidden bg-white flex flex-col"
+        style={{
+          transform: isDragging
+            ? `translateY(${dragDistance}px) scale(${Math.max(0.95, 1 - dragDistance / 1000)})`
+            : 'translateY(0) scale(1)',
+          transition: isDragging ? 'none' : 'transform 0.3s ease-out',
+        }}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+      >
+        {/* 드래그 핸들 */}
+        <div className="flex justify-center pt-2 pb-1 flex-shrink-0">
+          <div className="w-12 h-1 bg-gray-300 rounded-full"></div>
+        </div>
+        <div className="flex-1 overflow-hidden">
           {typeof children === 'function' ? children(handleClose) : children}
         </div>
       </div>

--- a/components/ModalHeader.tsx
+++ b/components/ModalHeader.tsx
@@ -1,21 +1,15 @@
 'use client';
 
-import { Button } from '@/components/ui/button';
-
 interface ModalHeaderProps {
-  onClose?: () => void;
   children?: React.ReactNode;
 }
 
-export function ModalHeader({ onClose, children }: ModalHeaderProps) {
+export function ModalHeader({ children }: ModalHeaderProps) {
   return (
-    <div className="bg-white sticky top-0 z-10 flex justify-center py-5 w-full">
-      {/* <Button
-        variant="ghost"
-        size="icon"
-        onClick={onClose}
-        className="w-26 h-2 rounded-md bg-custom-green text-white absolute left-0 right-0 mx-auto"
-      /> */}
+    <div className="bg-white sticky top-0 z-10">
+      <div className="flex justify-center pt-2">
+        <div className="w-26 h-2 rounded-md bg-custom-green text-white" />
+      </div>
       {children}
     </div>
   );

--- a/components/ModalHeader.tsx
+++ b/components/ModalHeader.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { ChevronDown } from 'lucide-react';
 
 interface ModalHeaderProps {
   onClose?: () => void;
@@ -10,18 +9,13 @@ interface ModalHeaderProps {
 
 export function ModalHeader({ onClose, children }: ModalHeaderProps) {
   return (
-    <div className="bg-white sticky top-0 z-10">
-      <div className="flex justify-center pt-2">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onClose}
-          className="w-10 h-10 rounded-full bg-custom-slate text-white"
-        >
-          <ChevronDown className="w-6 h-6" />
-        </Button>
-      </div>
-
+    <div className="bg-white sticky top-0 z-10 flex justify-center py-5 w-full">
+      {/* <Button
+        variant="ghost"
+        size="icon"
+        onClick={onClose}
+        className="w-26 h-2 rounded-md bg-custom-green text-white absolute left-0 right-0 mx-auto"
+      /> */}
       {children}
     </div>
   );

--- a/components/common/CommentForm.tsx
+++ b/components/common/CommentForm.tsx
@@ -62,7 +62,7 @@ export default function CommentForm({
               value={content}
               onChange={(e) => setContent(e.target.value)}
               placeholder={`${boardType === 'FUNDING' ? '펀딩' : '조각'} 상품에 대한 의견을 남겨보세요...`}
-              className="w-full p-3 border border-gray-200 text-gray-900 text-sm rounded-xl resize-none focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent bg-gray-50"
+              className="w-full p-3 border border-gray-200 text-gray-900 text-sm rounded-md resize-none focus:outline-none focus:ring-2 focus:ring-green-500 focus:border-transparent bg-white"
               rows={2}
               maxLength={500}
               disabled={loading}
@@ -71,7 +71,7 @@ export default function CommentForm({
           <Button
             type="submit"
             disabled={loading || !content.trim()}
-            className="px-4 py-3 bg-blue-600 text-white rounded-xl hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+            className="px-4 py-3 bg-green-600 text-white rounded-md hover:bg-green-700 disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
           >
             <Send size={16} />
           </Button>
@@ -79,7 +79,7 @@ export default function CommentForm({
         <div className="flex justify-between items-center mt-2 px-1">
           <span className="text-xs text-gray-400">{content.length}/500</span>
           {loading && (
-            <span className="text-xs text-blue-600 font-medium">
+            <span className="text-xs text-green-700 font-medium">
               작성 중...
             </span>
           )}


### PR DESCRIPTION
주요 변경사항
모달을 드래그(아래로) 하거나 백드롭 클릭 시 닫히도록 기능 추가
댓글 작성 폼이 항상 모달 하단에 노출되도록 레이아웃 개선
모달 상단 마진 및 높이 조정으로 모바일 UX 개선
사용하지 않는 ModalHeader의 onClose prop 및 관련 코드 정리
ESLint 오류 및 빌드 경고 해결
테스트
모바일/PC 환경에서 모달 드래그 및 백드롭 클릭 시 정상적으로 닫힘
댓글 작성 폼이 항상 보이고, 입력 및 등록 정상 동작 확인